### PR TITLE
README, docker-compose and docker-publish updates

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,14 @@ name: Publish Docker image
 
 on: 
   push: 
-
+   # trigger when any one of these files have been changed
+    paths:
+      - 'environment.yml'
+      - 'Dockerfile'
+      - 'conda-lock.yml'
+      - '.github/workflows/docker-build.yml'
+  # also allow manual trigger
+  workflow_dispatch:
       
 jobs:
   push_to_registry:

--- a/README.md
+++ b/README.md
@@ -319,9 +319,9 @@ how to run it individually from the command line.
 # Testing
    To verify the analysis python packages in JupyterLab, open terminal and run:
 
-    ```bash
-    pytest test/
-    ```
+```bash 
+pytest test/
+```
 ---
 # Dependencies
   - python=3.12.12

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ To remove all generated files and start fresh, you can run:
 make clean
 ```
 
+We also provide `scratch` target that removes the old files before generating new documents and reports:
+
+```bash
+make scratch
+```
+
 ## Option B – Run the project with Docker
 
 Running with Docker allows you to use a pre-built image that already
@@ -111,7 +117,7 @@ From the project root, open a terminal and run:
 
 ``` bash
 # Pull the image from Docker Hub (this may take a few minutes)
-docker pull lukeni777/income-indicators:latest
+docker pull lukeni777/income-indicators:7b04a79
 ```
 
 ### 3. Run the container and start JupyterLab
@@ -164,7 +170,13 @@ To remove all generated files and start fresh, you can run:
 ``` bash
 make clean
 ```
+ OR
 
+To remove the old files before generating new documents and reports, run:
+
+```bash
+make scratch
+```
 ---
 
 ## Data analysis pipeline
@@ -303,7 +315,13 @@ how to run it individually from the command line.
      ```bash
      make clean
      ```
+---
+# Testing
+   To verify the analysis python packages in JupyterLab, open terminal and run:
 
+    ```bash
+    pytest test/
+    ```
 ---
 # Dependencies
   - python=3.12.12

--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
   docker run --rm -p 8888:8888 \
     -v "$(pwd)":/workplace \
     -w /workplace \
-    lukeni777/income-indicators:latest
+    lukeni777/income-indicators:7b04a79
   unset MSYS_NO_PATHCONV
 else
   # macOS / Linux
   docker run --rm -p 8888:8888 \
     -v "$PWD":/workplace \
     -w /workplace \
-    lukeni777/income-indicators:latest
+    lukeni777/income-indicators:7b04a79
 fi
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: 522-group33-income-indicators:latest
+    image: 522-group33-income-indicators:7b04a79
+
     container_name: 522-group33-income-indicators
     ports:
       - "8888:8888"


### PR DESCRIPTION
**Summary of changes:**
- Added changes to trigger rebuild and publish of dockerfile : 
         Milestone 2 feedback: GitHub Actions workflow: add conda-linux-64.lock as a push trigger path so the image rebuilds when the lockfile changes.
- Updated docker-compose.yml to use a specific docker image:
          Milestone 2 feedback: docker-compose.yml: specify an image tag (pin the exact image version instead of using an untagged/latest image).
- Updated README.md to include make scratch and testing steps